### PR TITLE
fixed non-standard html,added messages block

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -6,29 +6,24 @@
     <title>Flask Blog</title>
     <link rel="stylesheet" href="/static/css/foundation.css" />
     <script src="/static/js/vendor/modernizr.js"></script>
-  
   </head>
-  
-  {% with messages = get_flashed_messages() %}
-  {% if messages %}
-    <ul class=flashes>
-    {% for message in messages %}
-      <li>{{ message }}</li>
-    {% endfor %}
-    </ul>
-  {% endif %}
-{% endwith %}
-
-   <body>
-
-          {% block body %}{% endblock %}
-      
-
-<script src="/static/js/vendor/jquery.js"></script>
+  <body>
+    {% block messages %}
+        {% with messages = get_flashed_messages() %}
+	        {% if messages %}
+    	       <ul class=flashes>
+    	            {% for message in messages %}
+      		            <li>{{ message }}</li>
+    		        {% endfor %}
+    	        </ul>
+  	        {% endif %}
+        {% endwith %}
+    {% endblock %}
+    {% block body %}{% endblock %}
+    <script src="/static/js/vendor/jquery.js"></script>
     <script src="/static/js/foundation.min.js"></script>
     <script>
       $(document).foundation();
     </script>
-  
-     </body>
-	</html>
+  </body>
+</html>


### PR DESCRIPTION
putting anything that is possibly going to display anything to the user between the closing `</head>` and opening `<body>` tags is not a very clean or standard way of doing things, its better to have the markup rendered inside of the body tag where it belongs, also so users can override the placement of the flashed messages in their templates, its helpful to add that chunk of code into its own jinja block. your welcome.
